### PR TITLE
style: run clang-format

### DIFF
--- a/RecoVertex/PrimaryVertexProducer/plugins/PVDumper.cc
+++ b/RecoVertex/PrimaryVertexProducer/plugins/PVDumper.cc
@@ -1,39 +1,42 @@
 #include "PVDumper.h"
-#include "DataFormats/VertexReco/interface/VertexFwd.h"
-#include "DataFormats/TrackReco/interface/TrackFwd.h"
 #include "DataFormats/Common/interface/Handle.h"
+#include "DataFormats/TrackReco/interface/TrackFwd.h"
+#include "DataFormats/VertexReco/interface/VertexFwd.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 
-#include "TrackingTools/TransientTrack/interface/TransientTrack.h"
 #include "RecoVertex/VertexPrimitives/interface/TransientVertex.h"
 #include "RecoVertex/VertexTools/interface/VertexDistanceXY.h"
+#include "TrackingTools/TransientTrack/interface/TransientTrack.h"
 
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "DataFormats/BeamSpot/interface/BeamSpot.h"
-#include "SimDataFormats/Associations/interface/TrackToTrackingParticleAssociator.h"
 #include "DataFormats/RecoCandidate/interface/TrackAssociation.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "SimDataFormats/Associations/interface/TrackToTrackingParticleAssociator.h"
 
 #include "RecoVertex/VertexTools/interface/GeometricAnnealing.h"
-#include <iostream>
 #include <fstream>
+#include <iostream>
 
 typedef TrackingParticleRefVector::iterator tp_iterator;
 
-PVDumper::PVDumper(const edm::ParameterSet& conf)
+PVDumper::PVDumper(const edm::ParameterSet &conf)
     : theTTBToken(esConsumes(edm::ESInputTag("", "TransientTrackBuilder"))), theConfig(conf) {
 
   trkToken = consumes<reco::TrackCollection>(conf.getParameter<edm::InputTag>("TrackLabel"));
   bsToken = consumes<reco::BeamSpot>(conf.getParameter<edm::InputTag>("beamSpotLabel"));
   vtxToken = consumes<reco::VertexCollection>(edm::InputTag("offlinePrimaryVertices"));
   trkTokenView = consumes<edm::View<reco::Track>>(conf.getParameter<edm::InputTag>("TrackLabel"));
+
+  // Open files
   f_trk.open("tracks_info.txt", std::ios::out);
   f_vtx.open("vertex_info.txt", std::ios::out);
   f_truth_vtx.open("truth_vertex_info.txt", std::ios::out);
   f_truth_trk.open("truth_track_info.txt", std::ios::out);
-  vec_TrackingParticle_Token_ = consumes<TrackingParticleCollection>(edm::InputTag("mix","MergedTrackTruth"));
-  vec_VertexParticle_Token_ = consumes<TrackingVertexCollection>(edm::InputTag("mix","MergedTrackTruth"));
+
+  vec_TrackingParticle_Token_ = consumes<TrackingParticleCollection>(edm::InputTag("mix", "MergedTrackTruth"));
+  vec_VertexParticle_Token_ = consumes<TrackingVertexCollection>(edm::InputTag("mix", "MergedTrackTruth"));
   associatorToken_ = consumes<reco::TrackToTrackingParticleAssociator>(edm::InputTag("quickTrackAssociatorByHits"));
 
   std::string trackSelectionAlgorithm =
@@ -49,62 +52,73 @@ PVDumper::PVDumper(const edm::ParameterSet& conf)
   produces<int>();
 }
 
-PVDumper::~PVDumper() {
-}
+PVDumper::~PVDumper() {}
 
-void PVDumper::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
-  
+void PVDumper::produce(edm::Event &iEvent, const edm::EventSetup &iSetup) {
+
   edm::Handle<TrackingParticleCollection> TruthTrackContainer;
   edm::Handle<TrackingVertexCollection> TruthVertexContainer;
   iEvent.getByToken(vec_TrackingParticle_Token_, TruthTrackContainer);
   iEvent.getByToken(vec_VertexParticle_Token_, TruthVertexContainer);
   const TrackingParticleCollection *tPC = TruthTrackContainer.product();
   const TrackingVertexCollection *tVC = TruthVertexContainer.product();
-  
+
   edm::Handle<reco::TrackToTrackingParticleAssociator> theAssociator;
   iEvent.getByToken(associatorToken_, theAssociator);
-  
-  unsigned int i=0;
-  std::map< const TrackingParticle*, unsigned int> trktru_map;
-  for (TrackingParticleCollection::const_iterator t = tPC -> begin(); t != tPC ->end(); ++t) { 
-    if ( t->eventId().bunchCrossing() != 0 ) continue;
+
+  unsigned int i = 0;
+  std::map<const TrackingParticle *, unsigned int> trktru_map;
+  for (TrackingParticleCollection::const_iterator t = tPC->begin(); t != tPC->end(); ++t) {
+
+    if (t->eventId().bunchCrossing() != 0)
+      continue;
+
     f_truth_trk << " TruthTrack ";
-    f_truth_trk << iEvent.luminosityBlock() << " " << iEvent.id().event() << " " << i << " ";//<< &(*t) ;
-    //f_truth_trk << t -> eventId().bunchCrossing() << " ";
+    f_truth_trk << iEvent.luminosityBlock() << " " << iEvent.id().event() << " " << i << " "; //<< &(*t) ;
+    // f_truth_trk << t -> eventId().bunchCrossing() << " ";
     f_truth_trk << " " << t->charge() << " " << t->px() << " " << t->py() << " " << t->pz() << " ";
     f_truth_trk << t->vx() << " " << t->vy() << " " << t->vz() << " dud ";
 
-    //It appears that the GEN information is only available for the primary vertex not the pileup ones
-    //so I am removing it
-    //if ( t->genParticle_begin() != t->genParticle_end() ) {
+    // It appears that the GEN information is only available for the primary
+    // vertex not the pileup ones so I am removing it if ( t->genParticle_begin()
+    // != t->genParticle_end() ) {
     //  const reco::GenParticle *gp = &(**(t->genParticle_begin()));
     //
     //  f_truth_trk << (*(t->genParticle_begin()))->momentum().rho() << " "
     //		  << (*(t->genParticle_begin()))->vertex().x() << " ";
     //  const reco::GenParticle *mother=gp;
-    //  // I want the vertex of the first decay - so the daughter of the top particle
-    //  while ( (mother->mother() != nullptr) && (mother->mother()->mother() != nullptr) ) mother=(const reco::GenParticle *)mother->mother();
-    //  f_truth_trk << mother->vertex().x() << " ";
-    //  
+    //  // I want the vertex of the first decay - so the daughter of the top
+    //  particle while ( (mother->mother() != nullptr) &&
+    //  (mother->mother()->mother() != nullptr) ) mother=(const
+    //  reco::GenParticle *)mother->mother(); f_truth_trk <<
+    //  mother->vertex().x() << " ";
+    //
     //}
-    //else{
+    // else{
     //  f_truth_trk << "0 0 0";
     //}
-    
+
     f_truth_trk << std::endl;
-    trktru_map[&(*t)]=i;
+    trktru_map[&(*t)] = i;
     i++;
   }
-  i=0;
-  for (TrackingVertexCollection::const_iterator v = tVC -> begin(); v != tVC ->end(); ++v) { 
-    if ( v->eventId().bunchCrossing() != 0 ) continue;
+
+  i = 0;
+  for (TrackingVertexCollection::const_iterator v = tVC->begin(); v != tVC->end(); ++v) {
+
+    if (v->eventId().bunchCrossing() != 0)
+      continue;
+
     f_truth_vtx << " TruthVertex ";
-    f_truth_vtx << iEvent.luminosityBlock() << " " << iEvent.id().event() << " " << i << " ";// << &(*v) << " ";
-    //f_truth_vtx << v -> eventId().bunchCrossing() << " ";
-    f_truth_vtx << v ->position().x() << " " << v->position().y() << " " << v->position().z() << " " << v -> daughterTracks().size() << " ";
-    for (tp_iterator iTP = v -> daughterTracks_begin(); iTP != v -> daughterTracks_end(); ++iTP) {
-      f_truth_vtx << trktru_map[&(*(*iTP))] << " ";// << &(*(*iTP)) << " " ;
+    f_truth_vtx << iEvent.luminosityBlock() << " " << iEvent.id().event() << " " << i << " "; // << &(*v) << " ";
+    // f_truth_vtx << v -> eventId().bunchCrossing() << " ";
+    f_truth_vtx << v->position().x() << " " << v->position().y() << " " << v->position().z() << " "
+                << v->daughterTracks().size() << " ";
+
+    for (tp_iterator iTP = v->daughterTracks_begin(); iTP != v->daughterTracks_end(); ++iTP) {
+      f_truth_vtx << trktru_map[&(*(*iTP))] << " "; // << &(*(*iTP)) << " " ;
     }
+
     f_truth_vtx << std::endl;
     i++;
   }
@@ -119,7 +133,8 @@ void PVDumper::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
 
   reco::RecoToSimCollection recSimColl = theAssociator->associateRecoToSim(trackCollectionV, TruthTrackContainer);
 
-  // get the BeamSpot, it will always be needed, even when not used as a constraint
+  // get the BeamSpot, it will always be needed, even when not used as a
+  // constraint
   reco::BeamSpot beamSpot;
   edm::Handle<reco::BeamSpot> recoBeamSpotHandle;
   iEvent.getByToken(bsToken, recoBeamSpotHandle);
@@ -130,61 +145,67 @@ void PVDumper::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   }
 
   // interface RECO tracks to vertex reconstruction
-  const auto& theB = &iSetup.getData(theTTBToken);
+  const auto &theB = &iSetup.getData(theTTBToken);
   std::vector<reco::TransientTrack> t_tks;
   t_tks = (*theB).build(tks, beamSpot);
 
   // select tracks
-  std::vector<reco::TransientTrack>&& seltks = theTrackFilter->select(t_tks);
+  std::vector<reco::TransientTrack> &&seltks = theTrackFilter->select(t_tks);
 
-  int i_val=0;
+  int i_val = 0;
   //    f_trk << "TrkInfo1 " << &i << " " << i.pt() << std::endl;
   // }
-  //for ( auto & i : seltks) {
+  // for ( auto & i : seltks) {
   //  const auto &my_trk= i;//.track();
 
-  std::map< const reco::Track*,unsigned int> trk_map;
-  for ( auto & i : (*tks)) {
-    int is_good=0;
-    const auto & my_trk = i;
-    trk_map[&my_trk]=i_val;
-    for ( auto & j : seltks) {
-      const auto &my_trkbase= j.trackBaseRef();
-      if ( &(*my_trkbase) == &i ){  is_good=true; break; }
+  std::map<const reco::Track *, unsigned int> trk_map;
+  for (auto &i : (*tks)) {
+    int is_good = 0;
+    const auto &my_trk = i;
+    trk_map[&my_trk] = i_val;
+    for (auto &j : seltks) {
+      const auto &my_trkbase = j.trackBaseRef();
+      if (&(*my_trkbase) == &i) {
+        is_good = true;
+        break;
+      }
     }
-    f_trk << "TrkInfo "<< iEvent.luminosityBlock() << " " << iEvent.id().event() << " ";
+    f_trk << "TrkInfo " << iEvent.luminosityBlock() << " " << iEvent.id().event() << " ";
     f_trk << i_val << " "; //<< " " << &my_trk << " "
     f_trk << is_good
-      //<< &my_trk << " " << &(*(my_trkbase)) 
-	  << " "  << my_trk.pt() << " ";// << my_trkbase->pt() << " ";
-    for ( unsigned ij=0; ij<5; ij++)
+          //<< &my_trk << " " << &(*(my_trkbase))
+          << " " << my_trk.pt() << " "; // << my_trkbase->pt() << " ";
+
+    for (unsigned ij = 0; ij < 5; ij++)
       f_trk << my_trk.parameter(ij) << " ";
     const reco::Track::CovarianceMatrix innerStateCovariance = my_trk.innerStateCovariance();
-    
-    //f_trk << "[ ";
-    for ( int ii=0; ii<5; ii++) {
-      //f_trk << "[ ";
-      for ( int ij=0; ij<5; ij++) {
-	f_trk << innerStateCovariance(ii,ij);
-	if (ij!=4) f_trk << ", ";
+
+    // f_trk << "[ ";
+    for (int ii = 0; ii < 5; ii++) {
+      // f_trk << "[ ";
+      for (int ij = 0; ij < 5; ij++) {
+        f_trk << innerStateCovariance(ii, ij);
+        if (ij != 4)
+          f_trk << ", ";
       }
-      //f_trk << " ]";
-      if (ii!=4) f_trk << ", ";
-      //else f_trk << " ";
+      // f_trk << " ]";
+      if (ii != 4)
+        f_trk << ", ";
+      // else f_trk << " ";
     }
-    //f_trk << " ] ";
+    // f_trk << " ] ";
 
     edm::RefToBase<reco::Track> trackref(trackCollectionV, i_val);
     reco::RecoToSimCollection::const_iterator f = recSimColl.find(trackref);
+
     if (f != recSimColl.end()) {
       TrackingParticleRef tp = f->val.front().first;
-      int tpVal=-1;
-      if ( trktru_map.find( &(*tp) ) != trktru_map.end() ) {
-	tpVal=trktru_map[&(*tp)];
+      int tpVal = -1;
+      if (trktru_map.find(&(*tp)) != trktru_map.end()) {
+        tpVal = trktru_map[&(*tp)];
       }
       f_trk << tpVal << " ";
     }
-
 
     f_trk << std::endl;
     i_val++;
@@ -193,16 +214,17 @@ void PVDumper::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   edm::Handle<reco::VertexCollection> vColl;
   iEvent.getByToken(vtxToken, vColl);
 
-  int i_vtx=0;
+  int i_vtx = 0;
   for (reco::VertexCollection::const_iterator v = vColl->begin(); v != vColl->end(); ++v) {
-    f_vtx << "VtxInfo " << " " <<iEvent.luminosityBlock() << " " << iEvent.id().event() << " " << i_vtx << " ";
+    f_vtx << "VtxInfo "
+          << " " << iEvent.luminosityBlock() << " " << iEvent.id().event() << " " << i_vtx << " ";
     f_vtx << v->position().x() << " " << v->position().y() << " " << v->position().z() << " ";
     f_vtx << v->xError() << " " << v->yError() << " " << v->zError() << " ";
     f_vtx << v->tracksSize() << " ";
-    for ( auto iv = v->tracks_begin(); iv != v->tracks_end(); iv++) {
+    for (auto iv = v->tracks_begin(); iv != v->tracks_end(); iv++) {
       f_vtx << trk_map[&(*(*iv))] << " ";
-      //f_vtx << &(*(*iv)) << " ";
-      //f_vtx << (*iv)->pt() << " ";
+      // f_vtx << &(*(*iv)) << " ";
+      // f_vtx << (*iv)->pt() << " ";
     }
     f_vtx << std::endl;
     i_vtx++;
@@ -210,10 +232,9 @@ void PVDumper::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
 
   auto result = std::make_unique<int>(1);
   iEvent.put(std::move(result));
-  
 }
 
-void PVDumper::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+void PVDumper::fillDescriptions(edm::ConfigurationDescriptions &descriptions) {
   // offlinePrimaryVertices
   edm::ParameterSetDescription desc;
   {
@@ -252,13 +273,15 @@ void PVDumper::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   {
     edm::ParameterSetDescription psd0;
     TrackFilterForPVFinding::fillPSetDescription(psd0);
-    psd0.add<int>("numTracksThreshold", 0);  // HI only
+    psd0.add<int>("numTracksThreshold", 0); // HI only
     desc.add<edm::ParameterSetDescription>("TkFilterParameters", psd0);
   }
   desc.add<edm::InputTag>("beamSpotLabel", edm::InputTag("offlineBeamSpot"));
   desc.add<edm::InputTag>("TrackLabel", edm::InputTag("generalTracks"));
-  desc.add<edm::InputTag>("TrackTimeResosLabel", edm::InputTag("dummy_default"));  // 4D only
-  desc.add<edm::InputTag>("TrackTimesLabel", edm::InputTag("dummy_default"));      // 4D only
+  desc.add<edm::InputTag>("TrackTimeResosLabel",
+                          edm::InputTag("dummy_default")); // 4D only
+  desc.add<edm::InputTag>("TrackTimesLabel",
+                          edm::InputTag("dummy_default")); // 4D only
 
   {
     edm::ParameterSetDescription psd0;
@@ -281,5 +304,5 @@ void PVDumper::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   descriptions.add("pvDumper", desc);
 }
 
-//define this as a plug-in
+// define this as a plug-in
 DEFINE_FWK_MODULE(PVDumper);

--- a/RecoVertex/PrimaryVertexProducer/plugins/PVDumper.h
+++ b/RecoVertex/PrimaryVertexProducer/plugins/PVDumper.h
@@ -3,7 +3,8 @@
 // Package:    PrimaryVertexProducer
 // Class:      PrimaryVertexProducer
 //
-/**\class PrimaryVertexProducer PrimaryVertexProducer.cc RecoVertex/PrimaryVertexProducer/src/PrimaryVertexProducer.cc
+/**\class PrimaryVertexProducer PrimaryVertexProducer.cc
+ RecoVertex/PrimaryVertexProducer/src/PrimaryVertexProducer.cc
 
  Description: steers tracker primary vertex reconstruction and storage
 
@@ -27,34 +28,35 @@
 #include "FWCore/Framework/interface/EventSetup.h"
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include <iostream>
 #include <fstream>
+#include <iostream>
 
-//#include "RecoVertex/PrimaryVertexProducer/interface/PrimaryVertexProducerAlgorithm.h"
+//#include
+//"RecoVertex/PrimaryVertexProducer/interface/PrimaryVertexProducerAlgorithm.h"
+#include "RecoVertex/PrimaryVertexProducer/interface/DAClusterizerInZT_vect.h"
+#include "RecoVertex/PrimaryVertexProducer/interface/DAClusterizerInZ_vect.h"
+#include "RecoVertex/PrimaryVertexProducer/interface/TrackClusterizerInZ.h"
+#include "RecoVertex/PrimaryVertexProducer/interface/TrackFilterForPVFindingBase.h"
+#include "TrackingTools/Records/interface/TransientTrackRecord.h"
 #include "TrackingTools/TransientTrack/interface/TransientTrack.h"
 #include "TrackingTools/TransientTrack/interface/TransientTrackBuilder.h"
-#include "TrackingTools/Records/interface/TransientTrackRecord.h"
-#include "RecoVertex/PrimaryVertexProducer/interface/TrackFilterForPVFindingBase.h"
-#include "RecoVertex/PrimaryVertexProducer/interface/TrackClusterizerInZ.h"
-#include "RecoVertex/PrimaryVertexProducer/interface/DAClusterizerInZ_vect.h"
-#include "RecoVertex/PrimaryVertexProducer/interface/DAClusterizerInZT_vect.h"
 
-#include "RecoVertex/PrimaryVertexProducer/interface/TrackFilterForPVFinding.h"
-#include "RecoVertex/PrimaryVertexProducer/interface/HITrackFilterForPVFinding.h"
-#include "RecoVertex/PrimaryVertexProducer/interface/GapClusterizerInZ.h"
-#include "RecoVertex/PrimaryVertexProducer/interface/DAClusterizerInZ.h"
-#include "RecoVertex/KalmanVertexFit/interface/KalmanVertexFitter.h"
 #include "RecoVertex/AdaptiveVertexFit/interface/AdaptiveVertexFitter.h"
+#include "RecoVertex/KalmanVertexFit/interface/KalmanVertexFitter.h"
+#include "RecoVertex/PrimaryVertexProducer/interface/DAClusterizerInZ.h"
+#include "RecoVertex/PrimaryVertexProducer/interface/GapClusterizerInZ.h"
+#include "RecoVertex/PrimaryVertexProducer/interface/HITrackFilterForPVFinding.h"
+#include "RecoVertex/PrimaryVertexProducer/interface/TrackFilterForPVFinding.h"
 //#include "RecoVertex/VertexTools/interface/VertexDistanceXY.h"
-#include "RecoVertex/VertexPrimitives/interface/VertexException.h"
-#include <algorithm>
-#include "RecoVertex/PrimaryVertexProducer/interface/VertexHigherPtSquared.h"
-#include "RecoVertex/VertexTools/interface/VertexCompatibleWithBeam.h"
 #include "DataFormats/Common/interface/ValueMap.h"
+#include "RecoVertex/PrimaryVertexProducer/interface/VertexHigherPtSquared.h"
+#include "RecoVertex/VertexPrimitives/interface/VertexException.h"
+#include "RecoVertex/VertexTools/interface/VertexCompatibleWithBeam.h"
+#include "SimDataFormats/Associations/interface/TrackToTrackingParticleAssociator.h"
 #include "SimDataFormats/PileupSummaryInfo/interface/PileupSummaryInfo.h"
 #include "SimDataFormats/TrackingAnalysis/interface/TrackingParticle.h"
 #include "SimDataFormats/TrackingAnalysis/interface/TrackingVertex.h"
-#include "SimDataFormats/Associations/interface/TrackToTrackingParticleAssociator.h"
+#include <algorithm>
 
 //
 // class declaration
@@ -62,12 +64,12 @@
 
 class PVDumper : public edm::one::EDProducer<> {
 public:
-  PVDumper(const edm::ParameterSet&);
+  PVDumper(const edm::ParameterSet &);
   ~PVDumper() override;
 
-  void produce(edm::Event&, const edm::EventSetup&) override;
+  void produce(edm::Event &, const edm::EventSetup &) override;
 
-  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+  static void fillDescriptions(edm::ConfigurationDescriptions &descriptions);
 
   // access to config
   edm::ParameterSet config() const { return theConfig; }
@@ -76,14 +78,14 @@ private:
   // ----------member data ---------------------------
 
   const edm::ESGetToken<TransientTrackBuilder, TransientTrackRecord> theTTBToken;
-  TrackFilterForPVFindingBase* theTrackFilter;
+  TrackFilterForPVFindingBase *theTrackFilter;
   edm::ParameterSet theConfig;
   edm::EDGetTokenT<reco::BeamSpot> bsToken;
   edm::EDGetTokenT<reco::VertexCollection> vtxToken;
   edm::EDGetTokenT<reco::TrackCollection> trkToken;
-  edm::EDGetTokenT<edm::ValueMap<float> > trkTimesToken;
-  edm::EDGetTokenT<edm::ValueMap<float> > trkTimeResosToken;
-  edm::EDGetTokenT<std::vector<PileupSummaryInfo> > vecPileupSummaryInfoToken_;
+  edm::EDGetTokenT<edm::ValueMap<float>> trkTimesToken;
+  edm::EDGetTokenT<edm::ValueMap<float>> trkTimeResosToken;
+  edm::EDGetTokenT<std::vector<PileupSummaryInfo>> vecPileupSummaryInfoToken_;
   edm::EDGetTokenT<TrackingParticleCollection> vec_TrackingParticle_Token_;
   edm::EDGetTokenT<TrackingVertexCollection> vec_VertexParticle_Token_;
   edm::EDGetTokenT<reco::TrackToTrackingParticleAssociator> associatorToken_;
@@ -91,4 +93,3 @@ private:
 
   std::ofstream f_trk, f_vtx, f_truth_vtx, f_truth_trk;
 };
-

--- a/RecoVertex/PrimaryVertexProducer/plugins/PrimaryVertexProducer.cc
+++ b/RecoVertex/PrimaryVertexProducer/plugins/PrimaryVertexProducer.cc
@@ -1,21 +1,21 @@
 #include "RecoVertex/PrimaryVertexProducer/interface/PrimaryVertexProducer.h"
-#include "DataFormats/VertexReco/interface/VertexFwd.h"
-#include "DataFormats/TrackReco/interface/TrackFwd.h"
 #include "DataFormats/Common/interface/Handle.h"
+#include "DataFormats/TrackReco/interface/TrackFwd.h"
+#include "DataFormats/VertexReco/interface/VertexFwd.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 
-#include "TrackingTools/TransientTrack/interface/TransientTrack.h"
 #include "RecoVertex/VertexPrimitives/interface/TransientVertex.h"
 #include "RecoVertex/VertexTools/interface/VertexDistanceXY.h"
+#include "TrackingTools/TransientTrack/interface/TransientTrack.h"
 
-#include "FWCore/Framework/interface/ESHandle.h"
 #include "DataFormats/BeamSpot/interface/BeamSpot.h"
+#include "FWCore/Framework/interface/ESHandle.h"
 
 #include "RecoVertex/VertexTools/interface/GeometricAnnealing.h"
 
-PrimaryVertexProducer::PrimaryVertexProducer(const edm::ParameterSet& conf)
+PrimaryVertexProducer::PrimaryVertexProducer(const edm::ParameterSet &conf)
     : theTTBToken(esConsumes(edm::ESInputTag("", "TransientTrackBuilder"))), theConfig(conf) {
   fVerbose = conf.getUntrackedParameter<bool>("verbose", false);
 
@@ -38,13 +38,14 @@ PrimaryVertexProducer::PrimaryVertexProducer(const edm::ParameterSet& conf)
   std::string clusteringAlgorithm =
       conf.getParameter<edm::ParameterSet>("TkClusParameters").getParameter<std::string>("algorithm");
   if (clusteringAlgorithm == "gap") {
-    theTrackClusterizer = new GapClusterizerInZ(
-        conf.getParameter<edm::ParameterSet>("TkClusParameters").getParameter<edm::ParameterSet>("TkGapClusParameters"));
+    theTrackClusterizer = new GapClusterizerInZ(conf.getParameter<edm::ParameterSet>("TkClusParameters")
+                                                    .getParameter<edm::ParameterSet>("TkGapClusParameters"));
   } else if (clusteringAlgorithm == "DA") {
     theTrackClusterizer = new DAClusterizerInZ(
         conf.getParameter<edm::ParameterSet>("TkClusParameters").getParameter<edm::ParameterSet>("TkDAClusParameters"));
   }
-  // provide the vectorized version of the clusterizer, if supported by the build
+  // provide the vectorized version of the clusterizer, if supported by the
+  // build
   else if (clusteringAlgorithm == "DA_vect") {
     theTrackClusterizer = new DAClusterizerInZ_vect(
         conf.getParameter<edm::ParameterSet>("TkClusParameters").getParameter<edm::ParameterSet>("TkDAClusParameters"));
@@ -59,18 +60,17 @@ PrimaryVertexProducer::PrimaryVertexProducer(const edm::ParameterSet& conf)
   }
 
   if (f4D) {
-    trkTimesToken = consumes<edm::ValueMap<float> >(conf.getParameter<edm::InputTag>("TrackTimesLabel"));
-    trkTimeResosToken = consumes<edm::ValueMap<float> >(conf.getParameter<edm::InputTag>("TrackTimeResosLabel"));
+    trkTimesToken = consumes<edm::ValueMap<float>>(conf.getParameter<edm::InputTag>("TrackTimesLabel"));
+    trkTimeResosToken = consumes<edm::ValueMap<float>>(conf.getParameter<edm::InputTag>("TrackTimeResosLabel"));
   }
 
   // select and configure the vertex fitters
   if (conf.exists("vertexCollections")) {
     std::vector<edm::ParameterSet> vertexCollections =
-        conf.getParameter<std::vector<edm::ParameterSet> >("vertexCollections");
+        conf.getParameter<std::vector<edm::ParameterSet>>("vertexCollections");
 
     for (std::vector<edm::ParameterSet>::const_iterator algoconf = vertexCollections.begin();
-         algoconf != vertexCollections.end();
-         algoconf++) {
+         algoconf != vertexCollections.end(); algoconf++) {
       algo algorithm;
       std::string fitterAlgorithm = algoconf->getParameter<std::string>("algorithm");
       if (fitterAlgorithm == "KalmanVertexFitter") {
@@ -90,8 +90,8 @@ PrimaryVertexProducer::PrimaryVertexProducer(const edm::ParameterSet& conf)
       produces<reco::VertexCollection>(algorithm.label);
     }
   } else {
-    edm::LogWarning("MisConfiguration")
-        << "this module's configuration has changed, please update to have a vertexCollections=cms.VPSet parameter.";
+    edm::LogWarning("MisConfiguration") << "this module's configuration has changed, please update to have a "
+                                           "vertexCollections=cms.VPSet parameter.";
 
     algo algorithm;
     std::string fitterAlgorithm = conf.getParameter<std::string>("algorithm");
@@ -114,15 +114,15 @@ PrimaryVertexProducer::PrimaryVertexProducer(const edm::ParameterSet& conf)
     produces<reco::VertexCollection>(algorithm.label);
   }
 
-  //check if this is a recovery iteration
+  // check if this is a recovery iteration
   fRecoveryIteration = conf.getParameter<bool>("isRecoveryIteration");
   if (fRecoveryIteration) {
     if (algorithms.empty()) {
       throw VertexException("PrimaryVertexProducer: No algorithm specified. ");
     } else if (algorithms.size() > 1) {
-      throw VertexException(
-          "PrimaryVertexProducer: Running in Recovery mode and more than one algorithm specified.  Please "
-          "only one algorithm.");
+      throw VertexException("PrimaryVertexProducer: Running in Recovery mode "
+                            "and more than one algorithm specified.  Please "
+                            "only one algorithm.");
     }
     recoveryVtxToken = consumes<reco::VertexCollection>(conf.getParameter<edm::InputTag>("recoveryVtxCollection"));
   }
@@ -141,8 +141,9 @@ PrimaryVertexProducer::~PrimaryVertexProducer() {
   }
 }
 
-void PrimaryVertexProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
-  // get the BeamSpot, it will always be needed, even when not used as a constraint
+void PrimaryVertexProducer::produce(edm::Event &iEvent, const edm::EventSetup &iSetup) {
+  // get the BeamSpot, it will always be needed, even when not used as a
+  // constraint
   reco::BeamSpot beamSpot;
   edm::Handle<reco::BeamSpot> recoBeamSpotHandle;
   iEvent.getByToken(bsToken, recoBeamSpotHandle);
@@ -160,14 +161,14 @@ void PrimaryVertexProducer::produce(edm::Event& iEvent, const edm::EventSetup& i
     edm::LogError("UnusableBeamSpot") << "Beamspot with invalid errors " << beamVertexState.error().matrix();
   }
 
-  //if this is a recovery iteration, check if we already have a valid PV
+  // if this is a recovery iteration, check if we already have a valid PV
   if (fRecoveryIteration) {
-    auto const& oldVertices = iEvent.get(recoveryVtxToken);
-    //look for the first valid (not-BeamSpot) vertex
-    for (auto const& old : oldVertices) {
+    auto const &oldVertices = iEvent.get(recoveryVtxToken);
+    // look for the first valid (not-BeamSpot) vertex
+    for (auto const &old : oldVertices) {
       if (!(old.isFake())) {
-        //found a valid vertex, write the first one to the collection and return
-        //otherwise continue with regular vertexing procedure
+        // found a valid vertex, write the first one to the collection and
+        // return otherwise continue with regular vertexing procedure
         auto result = std::make_unique<reco::VertexCollection>();
         result->push_back(old);
         iEvent.put(std::move(result), algorithms.begin()->label);
@@ -182,12 +183,12 @@ void PrimaryVertexProducer::produce(edm::Event& iEvent, const edm::EventSetup& i
   iEvent.getByToken(trkToken, tks);
 
   // interface RECO tracks to vertex reconstruction
-  const auto& theB = &iSetup.getData(theTTBToken);
+  const auto &theB = &iSetup.getData(theTTBToken);
   std::vector<reco::TransientTrack> t_tks;
 
   if (f4D) {
-    edm::Handle<edm::ValueMap<float> > trackTimesH;
-    edm::Handle<edm::ValueMap<float> > trackTimeResosH;
+    edm::Handle<edm::ValueMap<float>> trackTimesH;
+    edm::Handle<edm::ValueMap<float>> trackTimeResosH;
     iEvent.getByToken(trkTimesToken, trackTimesH);
     iEvent.getByToken(trkTimeResosToken, trackTimeResosH);
     t_tks = (*theB).build(tks, beamSpot, *(trackTimesH.product()), *(trackTimeResosH.product()));
@@ -201,10 +202,10 @@ void PrimaryVertexProducer::produce(edm::Event& iEvent, const edm::EventSetup& i
   }
 
   // select tracks
-  std::vector<reco::TransientTrack>&& seltks = theTrackFilter->select(t_tks);
+  std::vector<reco::TransientTrack> &&seltks = theTrackFilter->select(t_tks);
 
   // clusterize tracks in Z
-  std::vector<std::vector<reco::TransientTrack> >&& clusters = theTrackClusterizer->clusterize(seltks);
+  std::vector<std::vector<reco::TransientTrack>> &&clusters = theTrackClusterizer->clusterize(seltks);
 
   if (fVerbose) {
     std::cout << " clustering returned  " << clusters.size() << " clusters  from " << seltks.size()
@@ -214,19 +215,18 @@ void PrimaryVertexProducer::produce(edm::Event& iEvent, const edm::EventSetup& i
   // vertex fits
   for (std::vector<algo>::const_iterator algorithm = algorithms.begin(); algorithm != algorithms.end(); algorithm++) {
     auto result = std::make_unique<reco::VertexCollection>();
-    reco::VertexCollection& vColl = (*result);
+    reco::VertexCollection &vColl = (*result);
 
     std::vector<TransientVertex> pvs;
-    for (std::vector<std::vector<reco::TransientTrack> >::const_iterator iclus = clusters.begin();
-         iclus != clusters.end();
-         iclus++) {
+    for (std::vector<std::vector<reco::TransientTrack>>::const_iterator iclus = clusters.begin();
+         iclus != clusters.end(); iclus++) {
       double sumwt = 0.;
       double sumwt2 = 0.;
       double sumw = 0.;
       double meantime = 0.;
       double vartime = 0.;
       if (f4D) {
-        for (const auto& tk : *iclus) {
+        for (const auto &tk : *iclus) {
           const double time = tk.timeExt();
           const double err = tk.dtErrorExt();
           const double inverr = err > 0. ? 1.0 / err : 0.;
@@ -248,7 +248,7 @@ void PrimaryVertexProducer::produce(edm::Event& iEvent, const edm::EventSetup& i
         if (f4D) {
           if (v.isValid()) {
             auto err = v.positionError().matrix4D();
-            auto trkweightMap3d = v.weightMap();  // copy the 3 fit weights
+            auto trkweightMap3d = v.weightMap(); // copy the 3 fit weights
             err(3, 3) = vartime;
             v = TransientVertex(v.position(), meantime, err, v.originalTracks(), v.totalChiSquared());
             v.weightMap(trkweightMap3d);
@@ -266,7 +266,7 @@ void PrimaryVertexProducer::produce(edm::Event& iEvent, const edm::EventSetup& i
           }
         }
 
-      }  // else: no fit ==> v.isValid()=False
+      } // else: no fit ==> v.isValid()=False
 
       if (fVerbose) {
         if (v.isValid()) {
@@ -285,7 +285,7 @@ void PrimaryVertexProducer::produce(edm::Event& iEvent, const edm::EventSetup& i
       if (v.isValid() && (v.degreesOfFreedom() >= algorithm->minNdof) &&
           (!validBS || (*(algorithm->vertexSelector))(v, beamVertexState)))
         pvs.push_back(v);
-    }  // end of cluster loop
+    } // end of cluster loop
 
     if (fVerbose) {
       std::cout << "PrimaryVertexProducerAlgorithm::vertices  candidates =" << pvs.size() << std::endl;
@@ -321,7 +321,8 @@ void PrimaryVertexProducer::produce(edm::Event& iEvent, const edm::EventSetup& i
         if (fVerbose) {
           std::cout << "RecoVertex/PrimaryVertexProducer: "
                     << "Beamspot with invalid errors " << bse.matrix() << std::endl;
-          std::cout << "Will put Vertex derived from dummy-fake BeamSpot into Event.\n";
+          std::cout << "Will put Vertex derived from dummy-fake BeamSpot into "
+                       "Event.\n";
         }
       } else {
         vColl.push_back(reco::Vertex(beamSpot.position(), beamSpot.rotatedCovariance3D(), 0., 0., 0));
@@ -351,7 +352,7 @@ void PrimaryVertexProducer::produce(edm::Event& iEvent, const edm::EventSetup& i
   }
 }
 
-void PrimaryVertexProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+void PrimaryVertexProducer::fillDescriptions(edm::ConfigurationDescriptions &descriptions) {
   // offlinePrimaryVertices
   edm::ParameterSetDescription desc;
   {
@@ -390,13 +391,15 @@ void PrimaryVertexProducer::fillDescriptions(edm::ConfigurationDescriptions& des
   {
     edm::ParameterSetDescription psd0;
     TrackFilterForPVFinding::fillPSetDescription(psd0);
-    psd0.add<int>("numTracksThreshold", 0);  // HI only
+    psd0.add<int>("numTracksThreshold", 0); // HI only
     desc.add<edm::ParameterSetDescription>("TkFilterParameters", psd0);
   }
   desc.add<edm::InputTag>("beamSpotLabel", edm::InputTag("offlineBeamSpot"));
   desc.add<edm::InputTag>("TrackLabel", edm::InputTag("generalTracks"));
-  desc.add<edm::InputTag>("TrackTimeResosLabel", edm::InputTag("dummy_default"));  // 4D only
-  desc.add<edm::InputTag>("TrackTimesLabel", edm::InputTag("dummy_default"));      // 4D only
+  desc.add<edm::InputTag>("TrackTimeResosLabel",
+                          edm::InputTag("dummy_default")); // 4D only
+  desc.add<edm::InputTag>("TrackTimesLabel",
+                          edm::InputTag("dummy_default")); // 4D only
 
   {
     edm::ParameterSetDescription psd0;
@@ -419,5 +422,5 @@ void PrimaryVertexProducer::fillDescriptions(edm::ConfigurationDescriptions& des
   descriptions.add("primaryVertexProducer", desc);
 }
 
-//define this as a plug-in
+// define this as a plug-in
 DEFINE_FWK_MODULE(PrimaryVertexProducer);


### PR DESCRIPTION
Just running a formatter, and adding a few blank lines and a note or two to make it easier to read.

I actually ran `clang-format --style="{BasedOnStyle: llvm, ColumnLimit: 120}" -i plugins/PVDumper.* plugins/PrimaryVertexProducer.cc` instead of `--style=llvm` because the 80 char limit was pretty severe.